### PR TITLE
Remove the unrequired statement about including the drush class

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Do **not** use any other `puppet-composer` module.
 Usage
 -----
 
-Include the `drush::drush` class:
-
-    include drush::drush
-
 You can specify the version you want to install:
 
     drush::drush { 'drush8':


### PR DESCRIPTION
The drush class isn't required unless resources are being created from a hash (or from hiera).

Rather than create confusion I'm thinking it should be removed.